### PR TITLE
Fix node.js version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,32 +3,39 @@ FROM debian:stable-slim
 ARG version=2.3.0
 ARG dl_url=http://web-builds.airdcpp.net/stable/airdcpp_${version}_webui-${version}_64-bit_portable.tar.gz
 
-RUN runtimeDeps=' \
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+RUN installDeps=' \
         curl \
+        gnupg \
+    ' \
+    && runtimeDeps=' \
         locales \
     ' \
 # Install runtime dependencies
     && export DEBIAN_FRONTEND=noninteractive \
     && apt-get update \
     && apt-get install -y --no-install-recommends $runtimeDeps \
+    && apt-get install -y --no-install-recommends $installDeps \
+    && locale-gen en_US.UTF-8 \
 # Install node.js to enable airdcpp extensions
-    && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
+    && curl -sL http://deb.nodesource.com/setup_8.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
-    && rm -rf /var/lib/apt/lists/*
-
 # Setup application
-RUN mkdir /Downloads /Share
-RUN curl $dl_url | tar -xz -C /
+    && mkdir /Downloads /Share \
+    && curl $dl_url | tar -xz -C / \
+# Clean up
+    && apt-get purge -y $installDeps \
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/* 
+
 WORKDIR /airdcpp-webclient
 COPY dcppboot.xml dcppboot.xml
 COPY .airdcpp/ /.airdcpp
 RUN chmod -R ugo+w /.airdcpp
-
-# Install and set locale
-RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
 
 VOLUME /.airdcpp
 EXPOSE 5600 5601


### PR DESCRIPTION
Related to issue #8.
Fixes two problems:
1. curl can't verify the certificate when calling `curl -sL https://deb.nodesource.com/setup_8.x` and because of `-s` `bash -` basically gets an empty input
2. The downloaded script requires gnupg as mentioned in the issue.

I also moved things around a bit and separated the dependencies in install and runtime to keep the image smaller.