### PR TITLE
disable root check if podman was detected

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 set -x
 
+is_podman() {
+    if [[ "$container" -eq podman ]]; then
+        true
+    else
+        if [[ "$container" -eq oci ]]; then
+            [[ -f /run/.containerenv ]]
+        else false
+        fi
+    fi
+}
+
 if [[ "$(id -u)" -ne 0 ]]
 then
     # Container is run as a normal user, check permissions

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,6 +40,12 @@ then
     exec /airdcpp-webclient/airdcppd "$@"
 else
     # Container is run as root
+    if is_podman
+    then
+        printf "this is podman, cool!\n"
+    else
+        printf "this is not podman, do our checks\n"
+    fi
 
     # Check PUID/PGID values
     if [[ -z "${PUID}" || -z "${PGID}" ]]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ is_podman() {
     fi
 }
 
-if [[ "$(id -u)" -ne 0 ]]
+if is_podman || [[ ( "$(id -u)" -ne 0 ) ]]
 then
     # Container is run as a normal user, check permissions
     find /.airdcpp -print0 |
@@ -40,12 +40,6 @@ then
     exec /airdcpp-webclient/airdcppd "$@"
 else
     # Container is run as root
-    if is_podman
-    then
-        printf "this is podman, cool!\n"
-    else
-        printf "this is not podman, do our checks\n"
-    fi
 
     # Check PUID/PGID values
     if [[ -z "${PUID}" || -z "${PGID}" ]]


### PR DESCRIPTION
Should hopefully fix #23, though only tested for podman, not docker (my systems only run cgroups v2), so it would be nice if a docker user tested this before merge